### PR TITLE
Fix D202 pep257 violation (remove blank line)

### DIFF
--- a/linter.py
+++ b/linter.py
@@ -53,7 +53,6 @@ class Pylint(PythonLinter):
         We override this to deal with the idiosyncracies of pylint's error messages.
 
         """
-
         match, line, col, error, warning, message, near = super().split_match(match)
 
         if match:


### PR DESCRIPTION
Basically get rid of this error:

```
$ pep257 .
./linter.py:49 in public method `split_match`:
        D202: No blank lines allowed *after* method docstring, found 1
The command "pep257 ." exited with 1.
```
