### PR TITLE
Be less strict when detecting version

### DIFF
--- a/linter.py
+++ b/linter.py
@@ -27,7 +27,7 @@ class Pylint(PythonLinter):
         '--persistent=n',   # don't save the old score (no sense for temp)
     )
     version_args = '--version'
-    version_re = r'^pylint.* (?P<version>\d+\.\d+\.\d+),'
+    version_re = r'pylint.* (?P<version>\d+\.\d+\.\d+),'
     version_requirement = '>= 1.0'
     regex = (
         r'^(?P<line>\d+):(?P<col>\d+):'


### PR DESCRIPTION
I think this fixes #4 for me, but I use nix-env, not virtualenv.

SublimeLinter will try to import the file as module, fail, and fall back to executing it. In theory.
