### PR TITLE
fix SublimeLinter/SublimeLinter-pylint#12

### DIFF
--- a/linter.py
+++ b/linter.py
@@ -58,6 +58,7 @@ class Pylint(PythonLinter):
         '--rcfile=': '',
     }
     inline_overrides = ('enable', 'disable')
+    module = 'pylint'
     check_version = True
 
     #############


### PR DESCRIPTION
This is how pep257 and flake8 linters are initialized, not sure why pylint isn't. Feel free to deny the pull, if there are legit reasons for not using `module = 'pylint'`.