### PR TITLE
Remove @python from cmd to avoid forcing system-default python

### DIFF
--- a/linter.py
+++ b/linter.py
@@ -19,7 +19,7 @@ class Pylint(PythonLinter):
 
     syntax = 'python'
     cmd = (
-        'pylint@python',
+        'pylint',
         '--msg-template=\'{line}:{column}:{msg_id}: {msg}\'',
         '--module-rgx=.*',  # don't check the module name
         '--reports=n',      # remove tables


### PR DESCRIPTION
I use exclusively Python3 and don't have `pylint` installed for Python2. I also have `"@python": 3` in plugin settings. The plugin was failing to start because the `pylint` executable was run with the system-default python (2.7). I traced it down to the `cmd='pylint@python'` in the linter. Evidently, the `@python` pragma was forcing the default Python version. Without it, the plugin works.

Not sure if this is the right change. Please review.