### PR TITLE
Add setting `use_package_names`

### DIFF
--- a/linter.py
+++ b/linter.py
@@ -1,6 +1,8 @@
 import logging
+import os
 import re
 from SublimeLinter.lint import PythonLinter
+from SublimeLinter.lint.linter import substitute_variables
 
 
 logger = logging.getLogger('SublimeLinter.plugins.pylint')
@@ -20,7 +22,12 @@ class Pylint(PythonLinter):
         'paths': [],
         'selector': 'source.python',
         '--rcfile=': '',
-        '--init-hook=;': None
+        '--init-hook=;': None,
+
+        # Instead of sending the file *path* to pylint as an arg,
+        # convert it to a ('dotted') package name relative to the
+        # working dir.
+        'use_package_names': False
     }
 
     def on_stderr(self, stderr):
@@ -49,8 +56,29 @@ class Pylint(PythonLinter):
             '--module-rgx=.*',  # don't check the module name
             '--reports=n',      # remove tables
             '--persistent=n',   # don't save the old score (no sense for temp)
-            '${args}'
+            '${args}',
+            '${file_on_disk}'
         )
+
+    def finalize_cmd(self, cmd, context, **_kwargs):
+        # Note: `kwargs` and calling `super() is not necessary, bc they
+        # only implement deprecated features.
+
+        settings = self.get_view_settings()
+        if settings.get('use_package_names', False):
+            cwd = self.get_working_dir(settings)
+            filename = context.get('file_on_disk', '')
+            cwd, filename = map(os.path.normpath, (cwd, filename))
+
+            if os.path.commonprefix([cwd, filename]):
+                rel_path = os.path.relpath(filename, cwd)
+                package_name = '.'.join(
+                    os.path.splitext(rel_path)[0].split(os.path.sep)
+                )
+
+                cmd = cmd[:-1] + [package_name]
+
+        return substitute_variables(context, cmd)
 
     #############
     # Try to extract a meaningful columns.


### PR DESCRIPTION
Instead of using the file path as arg which pylint will in turn
convert to a package name, we do the conversion on our own.

This implementation takes the file path of the view relative to
the defined working dir (usually the project path) and then basically
swaps '/' with '.'.

Fixes #36 

Feel free to bike-shed the name of the setting. 