### PR TITLE
Change `self.get_view_settings()` to `self.settings`

### DIFF
--- a/linter.py
+++ b/linter.py
@@ -33,7 +33,7 @@ class Pylint(PythonLinter):
             logger.error(stderr)
 
     def cmd(self):
-        settings = self.get_view_settings()
+        settings = self.settings
         if settings['init-hook'] is None:
             paths = settings['paths']
             if paths:


### PR DESCRIPTION
It appears that [`SublimeLinter#get_view_settings`](http://www.sublimelinter.com/en/v3.10.10/linter_methods.html#get-view-settings)
has been deprecatedand replaced by a simple call to `self.settings`.

This commit makes the appropriate change and returns
`SublimeLinter-pylint` to a working state with no warnings.