### PR TITLE
changed `on_stderr` to filter deprecation errors

### DIFF
--- a/linter.py
+++ b/linter.py
@@ -27,6 +27,7 @@ class Pylint(PythonLinter):
         stderr = re.sub(
             'No config file found, using default configuration\n', '', stderr)
         stderr = re.sub('Using config file .+\n', '', stderr)
+        stderr = re.sub('(?m)^.*DeprecationWarning.*\n.*\n', '', stderr)
 
         if stderr:
             self.notify_failure()


### PR DESCRIPTION
- can sometimes occur when using pylint's `extension-pkg-whitelist`
  option

resolves #59 